### PR TITLE
Added #FASTLY hash macro

### DIFF
--- a/app/code/community/Fastly/CDN/etc/default.vcl
+++ b/app/code/community/Fastly/CDN/etc/default.vcl
@@ -158,7 +158,7 @@ sub vcl_hash {
         set req.hash += req.http.cookie:FASTLY_CDN_ENV;
     }
 
-    set req.hash += "#####GENERATION#####";
+    #FASTLY hash
 
     if (!(req.url ~ "^/(media|js|skin)/.*\.(png|jpg|jpeg|gif|css|js|swf|ico)$")) {
         call design_exception;


### PR DESCRIPTION
Without "#FASTLY hash", UI complains of invalid VCL. Default macro appends the "#####GENERATION#####" .