### PR TITLE
Disable gzip on pass

### DIFF
--- a/app/code/community/Fastly/CDN/etc/default.vcl
+++ b/app/code/community/Fastly/CDN/etc/default.vcl
@@ -163,6 +163,9 @@ sub vcl_recv {
 }
 
 sub vcl_pass {
+    # Deactivate gzip on origin
+    unset bereq.http.Accept-Encoding;
+
 #FASTLY pass
 }
 


### PR DESCRIPTION
When passing, be sure to unset the Accept-Encoding header so that
backends do not send compressed HTML that we then can't use for ESI.