### PR TITLE
Fix type conversion error

### DIFF
--- a/app/code/community/Fastly/CDN/Block/Adminhtml/System/Config/Fieldset/DictionariesMap.php
+++ b/app/code/community/Fastly/CDN/Block/Adminhtml/System/Config/Fieldset/DictionariesMap.php
@@ -72,7 +72,7 @@ class Fastly_CDN_Block_Adminhtml_System_Config_Fieldset_DictionariesMap
      */
     protected function _getRowTemplateHtml($dictionary)
     {
-        if($dictionary != -1) {
+        if(is_int($dictionary) == true && $dictionary != -1) {
             $name = $dictionary->name;
             $id = $dictionary->id;
             $html = '<tr id="'. $name .'">';


### PR DESCRIPTION
Each time Fastly config is opened, following is written to `systerm.log`:

```ERR (3): Notice: Object of class stdClass could not be converted to int  in /var/www/html/app/code/community/Fastly/CDN/Block/Adminhtml/System/Config/Fieldset/DictionariesMap.php on line 76```