### PR TITLE
Casts XML node to string before passing to Magento translate function

### DIFF
--- a/app/code/community/Fastly/CDN/Model/Observer.php
+++ b/app/code/community/Fastly/CDN/Model/Observer.php
@@ -779,7 +779,7 @@ class Fastly_CDN_Model_Observer
                     }
                 }
 
-                $fastlyVer = Mage::helper('fastlycdn')->__(Mage::getConfig()->getNode('modules/Fastly_CDN/version'));
+                $fastlyVer = Mage::helper('fastlycdn')->__((string) Mage::getConfig()->getNode('modules/Fastly_CDN/version'));
 
                 if(isset($fastlyVer)) {
                     if ($fastlyVer > trim(Mage::getStoreConfig(Fastly_CDN_Helper_Data::XML_FASTLY_MODULE_VERSION))) {


### PR DESCRIPTION
Logging into Magento Admin fires Fastly's `installedEvent` observer to detect upgrades and fire a GA event.  The issue is that `Mage::getConfig()->getNode('modules/Fastly_CDN/version')` returns an instance of `Mage_Core_Model_Config_Element` instead of a string.  Passing the aforementioned object into Magento's translate function `__()` produces the following PHP warning in Magento's `system.log` file:

> Warning: array_key_exists(): The first argument should be either a string or an integer  in /var/www/vagrant/public/shop/app/code/core/Mage/Core/Model/Translate.php on line 569

Casting this node (which is an instance of PHP's `SimpleXMLElement`) to a string resolves the issue.