### PR TITLE
Fix ESI include path, fix translate warnings.

### DIFF
--- a/app/code/community/Fastly/CDN/Model/Esi/Tag/Abstract.php
+++ b/app/code/community/Fastly/CDN/Model/Esi/Tag/Abstract.php
@@ -62,7 +62,7 @@ class Fastly_CDN_Model_Esi_Tag_Abstract extends Mage_Core_Model_Abstract
             $url = Mage::getUrl($esiUrl, array('_nosid' => true, '_query' => $query));
 
             // make url relative
-            $url = str_replace(Mage::getBaseUrl(), '/', $url);
+            $url = str_replace(Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB), '/', $url);
 
             $esiTag = Fastly_CDN_Helper_Esi::ESI_INCLUDE_OPEN
                 . preg_replace("/^https/", "http", $url)

--- a/app/code/community/Fastly/CDN/Model/Observer.php
+++ b/app/code/community/Fastly/CDN/Model/Observer.php
@@ -779,7 +779,7 @@ class Fastly_CDN_Model_Observer
                     }
                 }
 
-                $fastlyVer = Mage::helper('fastlycdn')->__(Mage::getConfig()->getNode('modules/Fastly_CDN/version'));
+                $fastlyVer = Mage::getConfig()->getNode('modules/Fastly_CDN/version');
 
                 if(isset($fastlyVer)) {
                     if ($fastlyVer > trim(Mage::getStoreConfig(Fastly_CDN_Helper_Data::XML_FASTLY_MODULE_VERSION))) {

--- a/app/code/community/Fastly/CDN/Model/Statistic.php
+++ b/app/code/community/Fastly/CDN/Model/Statistic.php
@@ -188,7 +188,7 @@ class Fastly_CDN_Model_Statistic extends Mage_Core_Model_Abstract
             // Site location
             'cd5'   =>  $this->getSiteLocation(),
             // Fastly version
-            'cd6'   =>  Mage::helper('fastlycdn')->__(Mage::getConfig()->getNode('modules/Fastly_CDN/version')),
+            'cd6'   =>  Mage::getConfig()->getNode('modules/Fastly_CDN/version'),
             // CID
             'cd7'   =>  (!$this->_cid) ? $this->getHelper()->getCID() : $this->_cid,
             // Anti spam protection

--- a/app/code/community/Fastly/CDN/sql/fastlycdn_setup/install-1.0.1.php
+++ b/app/code/community/Fastly/CDN/sql/fastlycdn_setup/install-1.0.1.php
@@ -57,7 +57,7 @@ if($connection->isTableExists($tableName) == true) {
 
     $statistic = Mage::getModel('fastlycdn/statistic');
     $cid = $statistic->generateCid();
-    Mage::getConfig()->saveConfig('system/full_page_cache/fastly/current_version', Mage::helper('fastlycdn')->__(Mage::getConfig()->getNode('modules/Fastly_CDN/version')));
+    Mage::getConfig()->saveConfig('system/full_page_cache/fastly/current_version', Mage::getConfig()->getNode('modules/Fastly_CDN/version'));
     Mage::getConfig()->saveConfig('system/full_page_cache/fastly/fastly_ga_cid', $cid);
 
     $sendInstalledReq = $statistic->sendInstalledReq();

--- a/app/code/community/Fastly/CDN/sql/fastlycdn_setup/upgrade-1.0.0-1.0.1.php
+++ b/app/code/community/Fastly/CDN/sql/fastlycdn_setup/upgrade-1.0.0-1.0.1.php
@@ -57,7 +57,7 @@ if($connection->isTableExists($tableName) == true) {
 
     $statistic = Mage::getModel('fastlycdn/statistic');
     $cid = $statistic->generateCid();
-    Mage::getConfig()->saveConfig('system/full_page_cache/fastly/current_version', Mage::helper('fastlycdn')->__(Mage::getConfig()->getNode('modules/Fastly_CDN/version')));
+    Mage::getConfig()->saveConfig('system/full_page_cache/fastly/current_version', Mage::getConfig()->getNode('modules/Fastly_CDN/version'));
     Mage::getConfig()->saveConfig('system/full_page_cache/fastly/fastly_ga_cid', $cid);
 
     $sendInstalledReq = $statistic->sendInstalledReq();


### PR DESCRIPTION
Multiple calls to `Mage::helper('fastlycdn')->__(Mage::getConfig()->getNode('modules/Fastly_CDN/version'))` cause a translate error. Mage::getConfig()->getNode() returns a simple xml object not a string. This can be cast to a string as in https://github.com/fastly/fastly-magento/pull/44 , but I don't see a point in translating a version string like 1.0.25.
Further, in some cases, ESI block get incorrect include path. By default `Mage::getBaseUrl()` returns not the `base url`, but  the `base url link` field from Magento -> System configuration -> Web. 
See `\Mage::getBaseUrl`
```
    public static function getBaseUrl($type = Mage_Core_Model_Store::URL_TYPE_LINK, $secure = null)
    {
        return self::app()->getStore()->getBaseUrl($type, $secure);
    }
```
Better to use Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB) to prevent unwanted path exclusions.
base url = domain.com/
base url link = domain.com/en/

will lead to wrong esi path `/fastlycdn/esi/page_links/?esi_data=...`
instead of  `/en/fastlycdn/esi/page_links/?esi_data=...`